### PR TITLE
Update to stabilized upstream dalek dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 [dependencies]
 clear_on_drop = "0.2.3"
 crypto-mac = "0.7"
-curve25519-dalek = { version = "1.0.0-pre.1", default-features = false }
+curve25519-dalek = { version = "1", default-features = false }
 digest = "0.8"
 hmac = "0.7"
 rand = { version = "0.6.0", default-features = false }
@@ -23,7 +23,7 @@ default-features = false
 
 [dependencies.merlin]
 optional = true
-version = "1.0.0-pre"
+version = "1"
 
 [features]
 nightly = ["clear_on_drop/nightly", "curve25519-dalek/nightly"]


### PR DESCRIPTION
Hi! This just bumps the version specifiers for the dalek crates to remove the `.pre` prerelease specifiers.